### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/packages/@ember/engine/index.ts
+++ b/packages/@ember/engine/index.ts
@@ -472,6 +472,9 @@ export function buildInitializerMethod<
   B extends 'initializers' | 'instanceInitializers',
   T extends B extends 'initializers' ? Engine : EngineInstance,
 >(bucketName: B, humanName: string) {
+  if (bucketName === '__proto__' || bucketName === 'constructor' || bucketName === 'prototype') {
+    throw new Error(`Invalid bucketName: ${bucketName}`);
+  }
   return function (this: typeof Engine, initializer: Initializer<T>) {
     // If this is the first initializer being added to a subclass, we are going to reopen the class
     // to make sure we have a new `initializers` object, which extends from the parent class' using


### PR DESCRIPTION
Potential fix for [https://github.com/pwnlaboratory/ember.js/security/code-scanning/1](https://github.com/pwnlaboratory/ember.js/security/code-scanning/1)

To fix the issue, we will validate the `bucketName` parameter to ensure it cannot be set to a prototype-polluting value like `__proto__`, `constructor`, or `prototype`. This can be achieved by adding a runtime check that explicitly rejects such values. This approach ensures that even if the type system is bypassed, the code remains secure.

The fix involves:
1. Adding a validation step for `bucketName` at the beginning of the `buildInitializerMethod` function.
2. Throwing an error if `bucketName` is set to a disallowed value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
